### PR TITLE
Bump internal version references

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
   steps:
     - name: Run command
       id: run-command
-      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/run-command-with-metadata@v0.2.0
+      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/run-command-with-metadata@v0.2.1
       with:
         command: ${{ inputs.command }}
 
@@ -58,7 +58,7 @@ runs:
 
     - name: Warn on failure
       if: ${{ !cancelled() && steps.get-oidc-creds.outcome == 'failure' }}
-      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/warn-and-continue@v0.2.0
+      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/warn-and-continue@v0.2.1
       with:
         message: 'Failed to get OIDC credentials when reporting DSO Metrics. Please investigate the failure.'
 
@@ -79,7 +79,7 @@ runs:
 
     - name: Warn on failure
       if: ${{ !cancelled() && steps.assume-dso-role.outcome == 'failure' }}
-      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/warn-and-continue@v0.2.0
+      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/warn-and-continue@v0.2.1
       with:
         message: 'Failed to assume DSO metrics cross-account role when reporting DSO Metrics. Please investigate the failure.'
 
@@ -91,7 +91,7 @@ runs:
         steps.assume-dso-role.outcome == 'success' &&
         inputs.event-type == 'test'
       continue-on-error: true
-      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/report-dso-event@v0.2.0
+      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/report-dso-event@v0.2.1
       with:
         # TODO add coverage
         args: >
@@ -106,7 +106,7 @@ runs:
 
     - name: Warn on failure
       if: ${{ !cancelled() && steps.report-test-metrics.outcome == 'failure' }}
-      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/warn-and-continue@v0.2.0
+      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/warn-and-continue@v0.2.1
       with:
         message: 'Failed to report test event metrics to the DSO Metrics API. Please investigate the failure.'
 
@@ -118,7 +118,7 @@ runs:
         steps.assume-dso-role.outcome == 'success' &&
         inputs.event-type == 'deploy'
       continue-on-error: true
-      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/report-dso-event@v0.2.0
+      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/report-dso-event@v0.2.1
       with:
         args: >
           -app "${{ inputs.app }}"
@@ -132,6 +132,6 @@ runs:
 
     - name: Warn on failure
       if: ${{ !cancelled() && steps.report-deploy-metrics.outcome == 'failure' }}
-      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/warn-and-continue@v0.2.0
+      uses: Enterprise-CMCS/mac-fc-report-dso-event/.github/actions/warn-and-continue@v0.2.1
       with:
         message: 'Failed to report deploy event metrics to the DSO Metrics API. Please investigate the failure.'


### PR DESCRIPTION
Any time a new version of the repo is released, the internal version references used in the local actions called by the top-level `action.yml` must be updated. I'd like to automate this because clearly it's easy to forget to do it, but for now I'll bump them manually

Testing: referenced this branch in a ProfessorMAC and saw the action succeed